### PR TITLE
maxlen

### DIFF
--- a/src/custom2hl7/PatientMapper/Record.cls
+++ b/src/custom2hl7/PatientMapper/Record.cls
@@ -55,7 +55,7 @@ Property LON As %String;
 
 Property HEALTHCAREEXPENSES As %String;
 
-Property HEALTHCARECOVERAGE As %String (MAXLEn = "") ;
+Property HEALTHCARECOVERAGE As %String(MAXLEN = "");
 
 Parameter RECORDMAPGENERATED = 1;
 


### PR DESCRIPTION
fixed a typo in custom2hl7.PatientMapper.Record.cls on HEALTHCARECOVERAGE property : 
MAXLEn instead of MAXLEN